### PR TITLE
Convert timespan select to use a regular select component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Page, PageSection } from '@patternfly/react-core';
+import { Card, Grid, GridItem, Page, PageSection, Title } from '@patternfly/react-core';
 import React from 'react';
 import { PullCountCard } from './PullCountCard';
 import { Timespan } from './Timespan';
@@ -80,8 +80,24 @@ export default class App extends React.Component<IAppProps, IAppState> {
     return (
       <Page className="rh-container-analytics-root">
         <PageSection>
-          <TimespanSelect onOptionSelected={this.onTimespanChange}/>
-          <PullCountCard data={this.data} timespan={this.state.timespan}/>
+          <Grid gutter="md">
+            <GridItem span={12}>
+                Activity for <TimespanSelect onOptionSelected={this.onTimespanChange}/>
+            </GridItem>
+            <GridItem span={12}>
+              <Title size="2xl">{this.state.timespan.toString()}</Title>
+            </GridItem>
+            <GridItem span={3}><Card>TODO</Card></GridItem>
+            <GridItem span={3}><Card>TODO</Card></GridItem>
+            <GridItem span={3}><Card>TODO</Card></GridItem>
+            <GridItem span={3}><Card>TODO</Card></GridItem>
+            <GridItem span={12}>
+              <PullCountCard data={this.data} timespan={this.state.timespan}/>
+            </GridItem>
+            <GridItem span={6}><Card>TODO</Card></GridItem>
+            <GridItem span={6}><Card>TODO</Card></GridItem>
+            <GridItem span={12}><Card>TODO</Card></GridItem>
+          </Grid>
         </PageSection>
       </Page>
     );

--- a/src/Timespan.ts
+++ b/src/Timespan.ts
@@ -89,4 +89,10 @@ export class Timespan {
       }
     }
   }
+
+  toString(): string {
+    const start = moment.utc(this.intervals[0].start);
+    const end = moment.utc(this.intervals[this.intervals.length - 1].end);
+    return `${start.format('MMM D, YYYY')} - ${end.format('MMM D, YYYY')}`;
+  }
 }

--- a/src/TimespanSelect.test.tsx
+++ b/src/TimespanSelect.test.tsx
@@ -15,8 +15,15 @@ describe('TimespanSelect component', () => {
 
   it('sets state on toggle', () => {
     const wrapper = shallow(<TimespanSelect onOptionSelected={callback}/>);
-    (wrapper.instance() as TimespanSelect).onChange('1');
-    expect(wrapper.state('value')).toEqual('1');
-    expect(callback).toBeCalledWith(Timespan.MONTHS_3);
+    (wrapper.instance() as TimespanSelect).onToggle(true);
+    expect(wrapper.state('isExpanded')).toEqual(true);
+  });
+
+  it('sets state on select', () => {
+    const wrapper = shallow(<TimespanSelect onOptionSelected={callback}/>);
+    const component = wrapper.instance() as TimespanSelect;
+    component.onSelect(null, component.options[3]);
+    expect(wrapper.state('isExpanded')).toEqual(false);
+    expect(wrapper.state('selected')).toEqual(component.options[3]);
   });
 });

--- a/src/TimespanSelect.tsx
+++ b/src/TimespanSelect.tsx
@@ -1,47 +1,58 @@
-import { FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Select, SelectOption, SelectOptionObject } from '@patternfly/react-core';
 import React from 'react';
 import { Timespan } from './Timespan';
+import { TimespanSelectOption } from './TimespanSelectOption';
 
 interface ITimespanSelectProps {
   onOptionSelected(timepan: Timespan): void;
 }
 
 interface ITimespanSelectState {
-  value: string;
+  selected: TimespanSelectOption;
+  isExpanded: boolean;
 }
 
 export class TimespanSelect extends React.Component<ITimespanSelectProps, ITimespanSelectState> {
 
-  options = [
-    {timespan: Timespan.DAYS_30, label: 'Last 30 days'},
-    {timespan: Timespan.MONTHS_3, label: 'Last 3 months'},
-    {timespan: Timespan.MONTHS_6, label: 'Last 6 months'},
-    {timespan: Timespan.YEARS_1, label: 'Last year'},
+  options: TimespanSelectOption[] = [
+    new TimespanSelectOption(Timespan.DAYS_30, 'Last 30 days'),
+    new TimespanSelectOption(Timespan.MONTHS_3, 'Last 3 months'),
+    new TimespanSelectOption(Timespan.MONTHS_6, 'Last 6 months'),
+    new TimespanSelectOption(Timespan.YEARS_1, 'Last year'),
   ];
 
   constructor(props: ITimespanSelectProps) {
     super(props);
-    this.state = {value: '0'};
-    this.props.onOptionSelected(this.options[0].timespan);
+    const option = this.options[0];
+    this.state = {isExpanded: false, selected: option};
+    this.props.onOptionSelected(option.timespan);
   }
 
-  onChange = (value: string) => {
-    this.setState({value});
-    this.props.onOptionSelected(this.options[+value].timespan);
+  onSelect = (event: any, selection: SelectOptionObject) => {
+    const option = selection as TimespanSelectOption;
+    this.setState({selected: option, isExpanded: false});
+    this.props.onOptionSelected(option.timespan);
+  }
+
+  onToggle = (isExpanded: boolean) => {
+    this.setState({isExpanded});
   }
 
   render() {
     return (
-      <FormSelect
+      <Select
         aria-label="Timespan selection"
         className="rh-timespan-select"
-        value={this.state.value}
-        onChange={this.onChange}
+        selections={this.state.selected}
+        isExpanded={this.state.isExpanded}
+        onSelect={this.onSelect}
+        onToggle={this.onToggle}
+        width={200}
       >
         {this.options.map((option, index) => {
-          return <FormSelectOption key={index} value={index} label={option.label} />;
+          return <SelectOption key={index} value={option} />;
         })}
-      </FormSelect>
+      </Select>
     );
   }
 }

--- a/src/TimespanSelectOption.test.tsx
+++ b/src/TimespanSelectOption.test.tsx
@@ -1,0 +1,11 @@
+import { Timespan } from './Timespan';
+import { TimespanSelectOption } from './TimespanSelectOption';
+
+describe('TimespanSelectOption', () => {
+
+  it('renders', () => {
+    const option = new TimespanSelectOption(Timespan.DAYS_30, 'foo');
+    expect(option.toString()).toBe('foo');
+  });
+
+});

--- a/src/TimespanSelectOption.tsx
+++ b/src/TimespanSelectOption.tsx
@@ -1,0 +1,16 @@
+import { SelectOptionObject } from '@patternfly/react-core';
+import { Timespan } from './Timespan';
+
+export class TimespanSelectOption implements SelectOptionObject {
+  timespan: Timespan;
+  label: string;
+
+  constructor(timespan: Timespan, label: string) {
+    this.timespan = timespan;
+    this.label = label;
+  }
+
+  toString = (): string => {
+    return this.label;
+  }
+}


### PR DESCRIPTION
FormSelect doesn't have a straightforward way to restrict the width and
the normal Select component is probably a better fit anyways. The layout
of the overall app has been rearranged with placeholders for future
cards.