### PR TITLE
Fix X axis labels for week interval ticks

### DIFF
--- a/src/PullCountStackChart.test.tsx
+++ b/src/PullCountStackChart.test.tsx
@@ -24,14 +24,21 @@ describe('PullCountStackChart component', () => {
   });
 
   it('formats ticks', () => {
-    const timespan = new Timespan(2, 'day', 'day');
+    let timespan = new Timespan(2, 'day', 'day');
     timespan.now = moment.utc('2019-01-01');
     timespan.intervals = timespan.createIntervals();
     const wrapper = shallow(<PullCountStackChart data={data} tags={['latest']} timespan={timespan}/>);
     const component = wrapper.instance() as PullCountStackChart;
     expect(component.formatTick(0)).toBe('30');
-    expect(component.formatTick(1)).toBe('');
+    expect(component.formatTick(1)).toBe('31');
+    expect(component.formatTick(2)).toBe('1');
     expect(component.formatTick(999)).toBe('');
+
+    timespan = new Timespan(2, 'month', 'week');
+    timespan.now = moment.utc('2019-01-01');
+    timespan.intervals = timespan.createIntervals();
+    wrapper.setProps({timespan});
+    expect(component.formatTick(0)).toBe('Nov 1');
   });
 
   it('formats labels', () => {

--- a/src/PullCountStackChart.tsx
+++ b/src/PullCountStackChart.tsx
@@ -8,6 +8,7 @@ import {
   chart_color_purple_300,
 } from '@patternfly/react-tokens';
 import * as _ from 'lodash';
+import moment from 'moment';
 import React from 'react';
 import { Timespan } from './Timespan';
 import { IPullCountTagRecord } from './types';
@@ -44,9 +45,8 @@ export class PullCountStackChart extends React.Component<IPullCountStackChartPro
       return '';
     }
 
-    // Only show alternating intervals for days to reduce clutter
-    if ((interval.unit === 'day') && (tick % 2 !== 0)) {
-      return '';
+    if (interval.unit === 'week') {
+      return moment.utc(interval.start).format('MMM D');
     }
 
     return interval.display;
@@ -134,7 +134,7 @@ export class PullCountStackChart extends React.Component<IPullCountStackChartPro
         width={600}
         themeColor={ChartThemeColor.multiUnordered}
       >
-        <ChartAxis tickValues={ticks} tickFormat={this.formatTick}/>
+        <ChartAxis tickValues={ticks} tickFormat={this.formatTick} fixLabelOverlap={true}/>
         <ChartAxis dependentAxis={true} showGrid={true}/>
         <ChartStack colorScale={this.colorScale}>
           {this.props.tags.map(


### PR DESCRIPTION
There's no need to return empty strings with the fixLabelOverlap option.